### PR TITLE
Fix: Use Git tag for artifact naming

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -27,7 +27,7 @@ jobs:
         run: "composer install ${{ env.COMPOSER_FLAGS }}"
       - name: Build Zip
         run: |
-          zip -r my-artifact *
+          zip -r artifact-${{ github.ref_name }} *
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -46,6 +46,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./my-artifact.zip
-          asset_name: my-artifact.zip
+          asset_path: ./artifact-${{ github.ref_name }}.zip
+          asset_name: artifact-${{ github.ref_name }}.zip
           asset_content_type: application/z


### PR DESCRIPTION
This change modifies the GitHub Actions workflow to use the Git tag (github.ref_name) when naming the build artifact.

Previously, the artifact was always named 'my-artifact.zip'. Now, it will be named 'artifact-<tag_name>.zip', allowing for clearer identification of artifact versions.